### PR TITLE
[ us-324 -> master ] CORS Headers and Register functions

### DIFF
--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -6,6 +6,7 @@ export const defaultConfig: IHapijsStarterServerConfig = {
 
     cors: true,
     corsOrigins: [],
+    corsHeaders: 'Content-Type, Authorization',
     defaultRoute: true,
     statusMonitor: true,
 

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -6,7 +6,7 @@ export const defaultConfig: IHapijsStarterServerConfig = {
 
     cors: true,
     corsOrigins: [],
-    corsHeaders: 'Content-Type, Authorization',
+    accessControlAllowHeaders: 'Content-Type, Authorization',
     defaultRoute: true,
     statusMonitor: true,
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,7 +223,7 @@ export class Server {
 
                 response.type('text/plain');
                 response.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-                response.header('Access-Control-Allow-Headers', this.config.corsHeaders);
+                response.header('Access-Control-Allow-Headers', this.config.accessControlAllowHeaders);
                 return response;
             },
             options: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,14 @@ export class Server {
         return this;
     }
 
+    public async registerAdditionalPlugin(plugin: Hapi.ServerRegisterPluginObject<any>) {
+        return await this.server.register(plugin);
+    }
+
+    public async registerExtension(extension: Hapi.ServerExtEventsObject) {
+        return await this.server.ext(extension);
+    }
+
     public async startServer() {
         await this.server.start();
         this.appLogger.info(`Server running at: ${this.server.info.uri}`);
@@ -215,7 +223,7 @@ export class Server {
 
                 response.type('text/plain');
                 response.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-                response.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+                response.header('Access-Control-Allow-Headers', this.config.corsHeaders);
                 return response;
             },
             options: {

--- a/src/models/ihapijsStarterServerConfig.ts
+++ b/src/models/ihapijsStarterServerConfig.ts
@@ -8,6 +8,7 @@ export interface IHapijsStarterServerConfig {
     port: number;
     cors: boolean;
     corsOrigins: string[];
+    corsHeaders: string;
     defaultRoute: boolean;
     statusMonitor: boolean;
     authEnabled: boolean;

--- a/src/models/ihapijsStarterServerConfig.ts
+++ b/src/models/ihapijsStarterServerConfig.ts
@@ -8,7 +8,7 @@ export interface IHapijsStarterServerConfig {
     port: number;
     cors: boolean;
     corsOrigins: string[];
-    corsHeaders: string;
+    accessControlAllowHeaders: string;
     defaultRoute: boolean;
     statusMonitor: boolean;
     authEnabled: boolean;


### PR DESCRIPTION
[Target Process](https://sevenhillstechnology.tpondemand.com/entity/328-api-authenticate-application-token)

Making CORS headers a configurable option, with the default being the only option before. Added public functions to register Hapi Plugin and Extensions (these functions are necessary for reperio-platform-api to use v5)